### PR TITLE
Fix product forms

### DIFF
--- a/group-13-project/src/app/creators/[id]/page.tsx
+++ b/group-13-project/src/app/creators/[id]/page.tsx
@@ -1,5 +1,5 @@
 
-import { fetchArtistById } from '@/lib/data'; 
+import { fetchArtistById } from '@/lib/data';
 import { notFound } from 'next/navigation';
 import { FaFacebook, FaInstagram, FaPinterest } from "react-icons/fa";
 import Image from 'next/image';
@@ -30,10 +30,9 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         <div className="flex items-center space-x-6">
           <Image
             src={'/mockup.png'}
+            height={500} width={500}
             alt={artistData.name}
             className="w-32 h-32 rounded-full border-4  border-yellow-400 object-cover"
-            width={100}
-            height={100}
           />
           <div>
             <h1 className="text-3xl font-semibold text-gray-900">{artistData.name}</h1>

--- a/group-13-project/src/app/creators/[id]/page.tsx
+++ b/group-13-project/src/app/creators/[id]/page.tsx
@@ -30,7 +30,6 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         <div className="flex items-center space-x-6">
           <Image
             src={'/mockup.png'}
-            height={500} width={500}
             alt={artistData.name}
             className="w-32 h-32 rounded-full border-4  border-yellow-400 object-cover"
             width={100}

--- a/group-13-project/src/app/ui/products/categorySelect.tsx
+++ b/group-13-project/src/app/ui/products/categorySelect.tsx
@@ -18,7 +18,7 @@ export default function CreateCategorySelect({
     };
 
     return (
-        <select name="category" id="category" defaultValue={defaultCategory} className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+        <select name="category" id="category" defaultValue={defaultCategory} className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" required>
             {createOptions()}
         </select>
     );

--- a/group-13-project/src/app/ui/products/createProductForm.tsx
+++ b/group-13-project/src/app/ui/products/createProductForm.tsx
@@ -21,14 +21,14 @@ export default function CreateProductForm() {
     const defaultCategory = fetchProductCategories()[0];
 
     return (
-        <form action={createProductWithId} id="create_form">
+        <form action={createProductWithId} id="create_form" className="max-w-sm mx-auto">
             <div className="mb-5">
                 <label htmlFor="product_name" className="block mb-2 text-sm font-medium text-gray-900">Product Name</label>
-                <input type="text" name="product_name" id="product_name" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required />
+                <input type="text" name="product_name" id="product_name" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" required />
             </div>
             <div className="mb-5">
                 <label htmlFor="price_in_cents" className="block mb-2 text-sm font-medium text-gray-900">Price ($)</label>
-                <input type="number" name="price_in_cents" step="0.01" min="0.01" id="price_in_cents" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required />
+                <input type="number" name="price_in_cents" step="0.01" min="0.01" id="price_in_cents" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" required />
             </div>
             <div className="mb-5">
                 <label htmlFor="category" className="block mb-2 text-sm font-medium text-gray-900">Category</label>
@@ -36,7 +36,7 @@ export default function CreateProductForm() {
             </div>
             <div className="mb-5">
                 <label htmlFor="description" className="block mb-2 text-sm font-medium text-gray-900">Description</label>
-                <textarea name="description" id="description" rows={9} className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required />
+                <textarea name="description" id="description" rows={9} className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" required />
             </div>
             <button type="submit" className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center">Submit</button>
         </form>

--- a/group-13-project/src/app/ui/products/deleteProductForm.tsx
+++ b/group-13-project/src/app/ui/products/deleteProductForm.tsx
@@ -21,7 +21,8 @@ export default function DeleteProductForm({
     const deleteProductWithId = deleteProduct.bind(null, product.product_id, user_id);
 
     return (
-        <form action={deleteProductWithId}>
+        <form action={deleteProductWithId} className="max-w-sm mx-auto">
+            <label className="block mb-2 text-sm font-medium text-gray-900">Item Name: {product.product_name}</label>
             <button type="submit" className="text-white bg-danger hover:bg-danger-hover focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center">Really Delete This Item?</button>
         </form>
     );

--- a/group-13-project/src/app/ui/products/editProductForm.tsx
+++ b/group-13-project/src/app/ui/products/editProductForm.tsx
@@ -30,15 +30,15 @@ export default function EditProductForm({
             </div>
             <div className="mb-5">
                 <label htmlFor="price_in_cents" className="block mb-2 text-sm font-medium text-gray-900">Price ($)</label>
-                <input type="number" name="price_in_cents" step="0.01" min="0.01" id="price_in_cents" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" defaultValue={product.price_in_cents/100} required /> {/** make helper function */}
+                <input type="number" name="price_in_cents" step="0.01" min="0.01" id="price_in_cents" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" defaultValue={product.price_in_cents/100} required />
             </div>
             <div className="mb-5">
                 <label htmlFor="category" className="block mb-2 text-sm font-medium text-gray-900">Category</label>
-                <input type="text" name="category" id="category" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="name@flowbite.com" defaultValue={product.category} required />
+                <CreateCategorySelect defaultCategory={product.category}></CreateCategorySelect>
             </div>
             <div className="mb-5">
                 <label htmlFor="description" className="block mb-2 text-sm font-medium text-gray-900">Description</label>
-                <input type="text" name="description" id="description" className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="name@flowbite.com" defaultValue={product.description} required />
+                <textarea name="description" id="description" rows={9} className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="name@flowbite.com" defaultValue={product.description} required />
             </div>
             <button type="submit" className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Submit</button>
             <Link href={deleteHref} className="btn btn-primary text-white bg-danger hover:bg-danger-hover focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center">Delete Item</Link>


### PR DESCRIPTION
A few changes were erroneously made in another merge.
- Re-enabled the category select in the item update form.
- Reverted a change that swapped the update form description from textarea to text.

While I was at it, updated formatting to be the same across all product forms.

Create page: /products/create
Update page: /products/cdea816e-d239-4251-bbda-e67d29dc9b39/edit
Delete page: /products/cdea816e-d239-4251-bbda-e67d29dc9b39/delete

Additionally, I apologize for stating that I updated my lint fix to match Divine, that commit should state that I updated my lint fix to match Kola's current code.